### PR TITLE
Improve fault tolerance for worker failures

### DIFF
--- a/arxiv_digest.py
+++ b/arxiv_digest.py
@@ -60,8 +60,10 @@ def llm_read_papers():
             for paper_dict in paper_dict_list
         ]
         for future in as_completed(futures):
-            paper_judgements_list.append(future.result())
-
+            try:
+                paper_judgements_list.append(future.result())
+            except Exception as e:
+                st.warning(f"Worker failed: {e}")
             progress = len(paper_judgements_list) / len(paper_dict_list)
             st.session_state.progress_bar.progress(progress)
             st.session_state.progress_text.text(


### PR DESCRIPTION
## Summary
- make `LLMPaperReader.read_paper` retry OpenAI calls and return neutral results on failure
- guard against worker exceptions in the main Streamlit app

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openai')*

------
https://chatgpt.com/codex/tasks/task_e_6840b54f36c4832dbc50f853f45810fb