### PR TITLE
✨ feat(config): move relevance threshold to config with default 0.8

### DIFF
--- a/arxiv_digest.py
+++ b/arxiv_digest.py
@@ -123,7 +123,7 @@ threshold = st.sidebar.slider(
     "Relevance threshold",
     min_value=0.0,
     max_value=1.0,
-    value=0.7,
+    value=config["default_relevance_threshold"],
     step=0.1,
     help="Papers with relevance scores above this threshold will be shown",
 )

--- a/config.json
+++ b/config.json
@@ -15,5 +15,6 @@
     ],
     "openai_model": "gpt-4.1-mini",
     "number_of_concurrent_tasks": 50,
-    "timeout_seconds": 40
+    "timeout_seconds": 40,
+    "default_relevance_threshold": 0.8
 }


### PR DESCRIPTION
## Summary
- Add `default_relevance_threshold` configuration option to `config.json` with value 0.8
- Update Streamlit slider to use config value instead of hardcoded 0.7
- Improves application configurability and increases default threshold for better paper filtering

## Test plan
- [ ] Verify config.json loads correctly with new field
- [ ] Confirm Streamlit slider displays 0.8 as default value
- [ ] Test that threshold changes still work as expected in UI
- [ ] Run application to ensure no breaking changes

🤖 Generated with [Claude Code](https://claude.ai/code)