### PR TITLE
Stamp the date into digest output filenames

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Daily arXiv Digest is a headless CLI tool that fetches papers from arXiv RSS fee
 ### Development and Running
 - `make run` or `make all` - Generate today's digest
 - `uv run python main.py` - Direct command (flags: `--config`, `--date`, `--force`)
-- `uv run python main.py --rethreshold X` - Rebuild digest.md/digest.json from saved scores.json at threshold X (no fetch/re-score; TL;DRs cached in tldrs.json)
+- `uv run python main.py --rethreshold X` - Rebuild digest-<date>.md/digest-<date>.json from saved scores-<date>.json at threshold X (no fetch/re-score; TL;DRs cached in tldrs-<date>.json)
 - `uv sync` - Install/update dependencies
 
 ### Testing
@@ -27,7 +27,7 @@ Daily arXiv Digest is a headless CLI tool that fetches papers from arXiv RSS fee
 - `src/logger.py` - JSONL activity logging to `logs/activity.jsonl`; inspect with `check_log.py`
 
 ### Key Design Patterns
-- **Idempotent runs**: Output is keyed by date; if `digests/<date>/digest.json` exists the run exits cleanly (exit 0) without API calls, unless `--force`
+- **Idempotent runs**: Output is keyed by date; if `digests/<date>/digest-<date>.json` exists the run exits cleanly (exit 0) without API calls, unless `--force`
 - **Multi-provider via one code path**: OpenAI, Anthropic, and OpenRouter are all accessed through the OpenAI SDK (base_url override + per-provider API key env var); structured output via `chat.completions.parse` with Pydantic models
 - **Concurrent Processing**: ThreadPoolExecutor (50 workers by default) for both scoring and TL;DR phases
 - **Error Resilience**: Retry logic with graceful fallbacks — failed scoring returns neutral (0.0) judgements, failed TL;DRs return empty strings, so a batch never aborts
@@ -38,13 +38,14 @@ Daily arXiv Digest is a headless CLI tool that fetches papers from arXiv RSS fee
 2. Concurrently score every paper against every topic
 3. Select judgements with relevance ≥ `relevance_threshold`
 4. Generate one TL;DR per selected paper (a paper can match several topics)
-5. Write `digest.json` (selected papers), `digest.md` (rendered digest grouped by topic), and `scores.json` (raw scores for every fetched paper, for re-filtering at any threshold without re-scoring)
+5. Write `digest-<date>.json` (selected papers), `digest-<date>.md` (rendered digest grouped by topic), and `scores-<date>.json` (raw scores for every fetched paper, for re-filtering at any threshold without re-scoring)
 
 ### Output Contract
-`digest.json` top-level: `date`, `generated_at`, `provider`, `model`, `relevance_threshold`, `arxiv_subjects`, `topics`, `stats {papers_fetched, papers_selected}`, `papers[]`.
+All four output files live in `digests/<date>/` and stamp the date into their filenames (`digest-<date>.{json,md}`, `scores-<date>.json`, `tldrs-<date>.json`) so they stay self-identifying when copied out; `src.digest.output_paths(output_dir, date_str)` is the single source of truth for these names.
+`digest-<date>.json` top-level: `date`, `generated_at`, `provider`, `model`, `relevance_threshold`, `arxiv_subjects`, `topics`, `stats {papers_fetched, papers_selected}`, `papers[]`.
 Each paper: `id`, `title`, `authors[]`, `url`, `abstract`, `tldr`, `matched_topics[] {topic, relevance, reason}` (only judgements ≥ threshold).
-`scores.json`: same metadata (no threshold/stats) with `papers[]` covering EVERY fetched paper; each has `judgements[] {topic, relevance, reason}` for ALL topics.
-`tldrs.json`: cache of `{paper_id: tldr}` accumulated across runs/rethresholds of the same date.
+`scores-<date>.json`: same metadata (no threshold/stats) with `papers[]` covering EVERY fetched paper; each has `judgements[] {topic, relevance, reason}` for ALL topics.
+`tldrs-<date>.json`: cache of `{paper_id: tldr}` accumulated across runs/rethresholds of the same date.
 Papers are sorted by max relevance, descending, in both files. On days with no arXiv announcements empty files are still written.
 
 ## Configuration

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,5 +88,5 @@ Cutting a release (all on `main`, after the feature branch has merged):
 
 ## Development Notes
 
-- The Streamlit UI was removed in the headless revamp; `digest.md` is the human-readable surface
+- The Streamlit UI was removed in the headless revamp; `digest-<date>.md` is the human-readable surface
 - `digests/` is gitignored — outputs are local artifacts consumed in place by humans/agents

--- a/README.md
+++ b/README.md
@@ -48,11 +48,11 @@ Generate today's digest with:
 uv run python main.py
 ```
 
-The digest is written to `digests/YYYY-MM-DD/`:
+The digest is written to `digests/YYYY-MM-DD/`, with the date stamped into every filename so the files stay self-identifying when copied out of their folder:
 
-- `digest.md` — human-readable digest, grouped by topic, with a TL;DR for each selected paper
-- `digest.json` — structured record (metadata, stats, and selected papers with scores and TL;DRs) for programmatic consumption
-- `scores.json` — raw relevance scores for every fetched paper against every topic, so you can re-filter at any threshold on the fly without re-scoring
+- `digest-YYYY-MM-DD.md` — human-readable digest, grouped by topic, with a TL;DR for each selected paper
+- `digest-YYYY-MM-DD.json` — structured record (metadata, stats, and selected papers with scores and TL;DRs) for programmatic consumption
+- `scores-YYYY-MM-DD.json` — raw relevance scores for every fetched paper against every topic, so you can re-filter at any threshold on the fly without re-scoring
 
 If the digest for the day already exists, the run exits cleanly without spending API calls; use `--force` to regenerate.
 Other flags: `--config <path>` to use another config file, `--date YYYY-MM-DD` to label the output folder (the arXiv feed always returns the latest announcement).
@@ -63,7 +63,7 @@ To re-render the digest at a different threshold without re-fetching or re-scori
 uv run python main.py --rethreshold 0.9
 ```
 
-This rebuilds `digest.md`/`digest.json` from the saved `scores.json`; TL;DRs are cached in `tldrs.json`, so changing the threshold back and forth costs no API calls once a paper's TL;DR has been generated.
+This rebuilds `digest-YYYY-MM-DD.md`/`digest-YYYY-MM-DD.json` from the saved `scores-YYYY-MM-DD.json`; TL;DRs are cached in `tldrs-YYYY-MM-DD.json`, so changing the threshold back and forth costs no API calls once a paper's TL;DR has been generated.
 
 The `digests/` folder is gitignored: digests are local artifacts meant to be read in place (by you or by an agent), not committed.
 

--- a/main.py
+++ b/main.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from dotenv import load_dotenv
 
-from src.digest import rethreshold_digest, run_digest
+from src.digest import output_paths, rethreshold_digest, run_digest
 
 load_dotenv()
 
@@ -63,7 +63,8 @@ def main():
         print(f"Rewrote {json_path} and {md_path}")
         return 0
 
-    json_path = output_dir / "digest.json"
+    paths = output_paths(output_dir, args.date)
+    json_path = paths["json"]
     if json_path.exists() and not args.force:
         print(f"Digest for {args.date} already exists at {json_path}; use --force to regenerate.")
         return 0
@@ -73,7 +74,7 @@ def main():
     print(
         f"Selected {stats['papers_selected']} of {stats['papers_fetched']} papers."
     )
-    print(f"Wrote {json_path}, {md_path}, and {json_path.parent / 'scores.json'}")
+    print(f"Wrote {json_path}, {md_path}, and {paths['scores']}")
     return 0
 
 

--- a/main.py
+++ b/main.py
@@ -1,8 +1,11 @@
 import argparse
 import json
+import re
 import sys
 from datetime import date
 from pathlib import Path
+
+DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 
 from dotenv import load_dotenv
 
@@ -13,7 +16,7 @@ load_dotenv()
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Generate a daily arXiv digest (digest.md + digest.json)."
+        description="Generate a daily arXiv digest (digest-<date>.md + digest-<date>.json)."
     )
     parser.add_argument(
         "--config", default="config.json", help="Path to the config file"
@@ -33,11 +36,18 @@ def main():
         "--rethreshold",
         type=float,
         metavar="X",
-        help="Rebuild digest.md/digest.json from the saved scores.json at "
-        "threshold X — no fetching or re-scoring; TL;DRs are only generated "
-        "for papers newly above the threshold",
+        help="Rebuild digest-<date>.md/digest-<date>.json from the saved "
+        "scores-<date>.json at threshold X — no fetching or re-scoring; TL;DRs "
+        "are only generated for papers newly above the threshold",
     )
     args = parser.parse_args()
+
+    if not DATE_RE.match(args.date):
+        print(
+            f"Invalid --date '{args.date}'; expected YYYY-MM-DD "
+            "(it names the output folder and is stamped into the filenames)."
+        )
+        return 1
 
     if not Path(args.config).exists():
         print(

--- a/src/digest.py
+++ b/src/digest.py
@@ -224,30 +224,45 @@ def render_markdown(digest):
     return "\n".join(lines)
 
 
-def write_outputs(digest, scores, output_dir):
+def output_paths(output_dir, date_str):
+    """Date-stamped paths for the four per-date output files.
+
+    The output folder already carries the date, but stamping the filenames too
+    keeps each file self-identifying when copied out of its folder.
+    """
+    output_dir = Path(output_dir)
+    return {
+        "json": output_dir / f"digest-{date_str}.json",
+        "md": output_dir / f"digest-{date_str}.md",
+        "scores": output_dir / f"scores-{date_str}.json",
+        "tldrs": output_dir / f"tldrs-{date_str}.json",
+    }
+
+
+def write_outputs(digest, scores, output_dir, date_str):
     output_dir = Path(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
-    json_path = output_dir / "digest.json"
-    md_path = output_dir / "digest.md"
-    scores_path = output_dir / "scores.json"
+    paths = output_paths(output_dir, date_str)
+    json_path = paths["json"]
+    md_path = paths["md"]
     with open(json_path, "w") as f:
         json.dump(digest, f, indent=2, ensure_ascii=False)
-    with open(scores_path, "w") as f:
+    with open(paths["scores"], "w") as f:
         json.dump(scores, f, indent=2, ensure_ascii=False)
     md_path.write_text(render_markdown(digest))
     return json_path, md_path
 
 
-def _load_tldr_cache(output_dir):
-    cache_path = Path(output_dir) / "tldrs.json"
+def _load_tldr_cache(output_dir, date_str):
+    cache_path = output_paths(output_dir, date_str)["tldrs"]
     if cache_path.exists():
         with open(cache_path) as f:
             return json.load(f)
     return {}
 
 
-def _save_tldr_cache(output_dir, tldrs):
-    cache_path = Path(output_dir) / "tldrs.json"
+def _save_tldr_cache(output_dir, date_str, tldrs):
+    cache_path = output_paths(output_dir, date_str)["tldrs"]
     with open(cache_path, "w") as f:
         json.dump(tldrs, f, indent=2, ensure_ascii=False)
 
@@ -259,7 +274,8 @@ def rethreshold_digest(config, date_str, output_dir, threshold):
     digest.json and only generated for papers newly above the threshold.
     """
     output_dir = Path(output_dir)
-    scores_path = output_dir / "scores.json"
+    paths = output_paths(output_dir, date_str)
+    scores_path = paths["scores"]
     if not scores_path.exists():
         raise FileNotFoundError(
             f"{scores_path} not found; run the full pipeline for this date first."
@@ -267,8 +283,8 @@ def rethreshold_digest(config, date_str, output_dir, threshold):
     with open(scores_path) as f:
         scores = json.load(f)
 
-    old_tldrs = _load_tldr_cache(output_dir)
-    json_path = output_dir / "digest.json"
+    old_tldrs = _load_tldr_cache(output_dir, date_str)
+    json_path = paths["json"]
     if json_path.exists():
         with open(json_path) as f:
             for paper in json.load(f)["papers"]:
@@ -312,7 +328,7 @@ def rethreshold_digest(config, date_str, output_dir, threshold):
             if not paper["tldr"]:
                 paper["tldr"] = tldr_map.get(paper["id"], "")
         old_tldrs.update({k: v for k, v in tldr_map.items() if v})
-    _save_tldr_cache(output_dir, old_tldrs)
+    _save_tldr_cache(output_dir, date_str, old_tldrs)
 
     digest = {
         "date": scores["date"],
@@ -330,7 +346,7 @@ def rethreshold_digest(config, date_str, output_dir, threshold):
     }
     with open(json_path, "w") as f:
         json.dump(digest, f, indent=2, ensure_ascii=False)
-    md_path = output_dir / "digest.md"
+    md_path = paths["md"]
     md_path.write_text(render_markdown(digest))
     logger.log_activity(
         "rethreshold", "completed", {"threshold": threshold, "selected": len(selected)}
@@ -347,7 +363,7 @@ def run_digest(config, date_str, output_dir):
         # so downstream consumers can tell the run happened.
         digest = build_digest(date_str, paper_df, pd.DataFrame(), {}, config)
         scores = build_scores(date_str, pd.DataFrame(), config)
-        json_path, md_path = write_outputs(digest, scores, output_dir)
+        json_path, md_path = write_outputs(digest, scores, output_dir, date_str)
         logger.log_activity("complete_run", "completed", {"papers_selected": 0})
         return digest, json_path, md_path
 
@@ -362,10 +378,10 @@ def run_digest(config, date_str, output_dir):
     tldrs = add_tldrs(llm_reader, paper_df, selected_df, config)
     digest = build_digest(date_str, paper_df, selected_df, tldrs, config)
     scores = build_scores(date_str, scored_df, config)
-    json_path, md_path = write_outputs(digest, scores, output_dir)
-    cache = _load_tldr_cache(output_dir)
+    json_path, md_path = write_outputs(digest, scores, output_dir, date_str)
+    cache = _load_tldr_cache(output_dir, date_str)
     cache.update({k: v for k, v in tldrs.items() if v})
-    _save_tldr_cache(output_dir, cache)
+    _save_tldr_cache(output_dir, date_str, cache)
     logger.log_activity(
         "complete_run",
         "completed",

--- a/src/digest.py
+++ b/src/digest.py
@@ -268,10 +268,10 @@ def _save_tldr_cache(output_dir, date_str, tldrs):
 
 
 def rethreshold_digest(config, date_str, output_dir, threshold):
-    """Rebuild digest.json/digest.md from a saved scores.json at a new threshold.
+    """Rebuild the dated digest.json/digest.md from saved scores at a new threshold.
 
     Skips fetching and scoring entirely; TL;DRs are reused from the existing
-    digest.json and only generated for papers newly above the threshold.
+    digest-<date>.json and only generated for papers newly above the threshold.
     """
     output_dir = Path(output_dir)
     paths = output_paths(output_dir, date_str)
@@ -355,7 +355,7 @@ def rethreshold_digest(config, date_str, output_dir, threshold):
 
 
 def run_digest(config, date_str, output_dir):
-    """Run the full pipeline and write digest.json + digest.md to output_dir."""
+    """Run the full pipeline and write the dated digest.json + digest.md to output_dir."""
     paper_df = fetch_papers(config)
 
     if paper_df.empty:


### PR DESCRIPTION
## What

Output files now use **date-stamped names** so each file stays self-identifying when copied out of its dated folder:

| Before | After |
|---|---|
| `digests/<date>/digest.md` | `digest-<date>.md` |
| `digest.json` | `digest-<date>.json` |
| `scores.json` | `scores-<date>.json` |
| `tldrs.json` | `tldrs-<date>.json` |

## How

- `src/digest.py` — new `output_paths(output_dir, date_str)` is the single source of truth for the four filenames; `date_str` threaded through `write_outputs`, `_load_tldr_cache`, `_save_tldr_cache`, and `rethreshold_digest`.
- `main.py` — existence check and the "Wrote …" print use the date-stamped paths.
- `README.md` / `AGENTS.md` — docs updated to the new naming.

## Verification

- Clean imports.
- `write_outputs` lands the four correctly-named files.
- `--rethreshold` round-trip reads `scores-<date>.json` + TL;DR cache and rewrites correctly (fixtures, no API calls).

## Note

Naming change applies **going forward** — existing `digests/` folders keep their old bare filenames, so `--rethreshold` on an old date won't find `scores-<date>.json`. The folder is gitignored/local, so it's harmless; re-run older dates with `--force` if needed.