### PR TITLE
feat(digest): flag cross-listed papers in the markdown render

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: run, help, all, check-log
+.PHONY: run, help, all, check-log, test
 
 all: run
 
@@ -7,11 +7,15 @@ help:
 	@echo "Targets:"
 	@echo "  all - Generate today's digest"
 	@echo "  run - Generate today's digest"
+	@echo "  test - Run offline rendering unit tests"
 	@echo "  check-log - Check activity logs"
 	@echo "  help - Display this help message"
 
 run:
 	uv run python main.py
+
+test:
+	uv run python test_digest.py
 
 check-log:
 	uv run python check_log.py

--- a/src/digest.py
+++ b/src/digest.py
@@ -179,6 +179,13 @@ def build_scores(date_str, scored_df, config):
     }
 
 
+def _short_topic(topic, limit=30):
+    """A compact label for a long topic sentence, truncated on a word boundary."""
+    if len(topic) <= limit:
+        return topic
+    return topic[:limit].rsplit(" ", 1)[0] + "…"
+
+
 def render_markdown(digest):
     """Render the digest record as a human-readable markdown document."""
     lines = [
@@ -221,6 +228,16 @@ def render_markdown(digest):
                 lines.append("")
             lines.append(f"**Relevance {match['relevance']:.2f}** — {match['reason']}")
             lines.append("")
+            others = [
+                t["topic"]
+                for t in paper["matched_topics"]
+                if t["topic"] != match["topic"]
+            ]
+            if others:
+                noun = "topic" if len(others) == 1 else "topics"
+                labels = ", ".join(_short_topic(t) for t in others)
+                lines.append(f"*Also matches {len(others)} other {noun}: {labels}*")
+                lines.append("")
     return "\n".join(lines)
 
 

--- a/src/digest.py
+++ b/src/digest.py
@@ -180,10 +180,35 @@ def build_scores(date_str, scored_df, config):
 
 
 def _short_topic(topic, limit=30):
-    """A compact label for a long topic sentence, truncated on a word boundary."""
+    """A compact label for a long topic sentence, truncated on a word boundary.
+
+    The result never exceeds ``limit`` characters (the appended ellipsis counts
+    toward the budget). Falls back to a hard cut when the prefix has no space.
+    """
     if len(topic) <= limit:
         return topic
-    return topic[:limit].rsplit(" ", 1)[0] + "…"
+    prefix = topic[: limit - 1]
+    head, sep, _ = prefix.rpartition(" ")
+    return (head if sep else prefix) + "…"
+
+
+def _topic_labels(topics, limit=30):
+    """Map each topic to a short display label, keeping labels distinguishable.
+
+    Two topics that share a long prefix would shorten to the same string, making
+    the cross-topic note ambiguous. When that happens, every topic in the
+    colliding group falls back to its full text so the note still identifies
+    which other topic matched.
+    """
+    labels = {topic: _short_topic(topic, limit) for topic in topics}
+    collisions = {}
+    for topic, label in labels.items():
+        collisions.setdefault(label, []).append(topic)
+    for group in collisions.values():
+        if len(group) > 1:
+            for topic in group:
+                labels[topic] = topic
+    return labels
 
 
 def render_markdown(digest):
@@ -203,6 +228,9 @@ def render_markdown(digest):
         lines.append("No papers passed the relevance threshold today.")
         lines.append("")
         return "\n".join(lines)
+
+    # Short, collision-safe labels for the cross-topic note below.
+    topic_labels = _topic_labels(digest["topics"])
 
     # Group papers by topic; a paper can appear under several topics.
     papers_by_topic = {}
@@ -235,7 +263,7 @@ def render_markdown(digest):
             ]
             if others:
                 noun = "topic" if len(others) == 1 else "topics"
-                labels = ", ".join(_short_topic(t) for t in others)
+                labels = ", ".join(topic_labels.get(t, _short_topic(t)) for t in others)
                 lines.append(f"*Also matches {len(others)} other {noun}: {labels}*")
                 lines.append("")
     return "\n".join(lines)

--- a/test_digest.py
+++ b/test_digest.py
@@ -1,0 +1,97 @@
+"""Offline unit checks for markdown rendering (no API keys / network needed).
+
+Run with: uv run python test_digest.py
+Covers the cross-topic note behavior shared by run_digest and --rethreshold,
+plus the short-label helpers.
+"""
+
+from src.digest import _short_topic, _topic_labels, render_markdown
+
+TOPIC_A = "Security and safety of AI and language models"
+TOPIC_B = "Factuality of AI systems, misinformation, and fact-checking"
+TOPIC_C = "AI and health information seeking, including AI chatbots"
+
+
+def _paper(title, topics):
+    return {
+        "id": title,
+        "title": title,
+        "authors": ["Ada Lovelace"],
+        "url": f"https://arxiv.org/abs/{title}",
+        "abstract": "",
+        "tldr": "A short summary.",
+        "matched_topics": [
+            {"topic": t, "relevance": r, "reason": "because"} for t, r in topics
+        ],
+    }
+
+
+def _digest(papers, topics):
+    return {
+        "date": "2026-07-22",
+        "provider": "openai",
+        "model": "gpt-5-mini",
+        "relevance_threshold": 0.8,
+        "arxiv_subjects": ["cs.CY"],
+        "topics": topics,
+        "stats": {"papers_fetched": 100, "papers_selected": len(papers)},
+        "papers": papers,
+    }
+
+
+def test_single_topic_paper_has_no_note():
+    md = render_markdown(_digest([_paper("solo", [(TOPIC_A, 0.9)])], [TOPIC_A]))
+    assert "Also matches" not in md
+
+
+def test_two_topics_uses_singular_noun():
+    paper = _paper("dual", [(TOPIC_A, 0.95), (TOPIC_B, 0.9)])
+    md = render_markdown(_digest([paper], [TOPIC_A, TOPIC_B]))
+    # Appears under both sections; each occurrence names the *other* topic only.
+    assert md.count("Also matches 1 other topic:") == 2
+    assert "Also matches 1 other topics" not in md  # correct singular
+    # Under the A section the note points to B, and vice versa.
+    a_idx, b_idx = md.index(f"## {TOPIC_A}"), md.index(f"## {TOPIC_B}")
+    a_note = md[a_idx:b_idx]
+    assert _short_topic(TOPIC_B) in a_note and _short_topic(TOPIC_A) not in a_note
+
+
+def test_three_topics_uses_plural_noun():
+    paper = _paper("triple", [(TOPIC_A, 0.95), (TOPIC_B, 0.9), (TOPIC_C, 0.85)])
+    md = render_markdown(_digest([paper], [TOPIC_A, TOPIC_B, TOPIC_C]))
+    assert md.count("Also matches 2 other topics:") == 3
+
+
+def test_short_topic_respects_limit_and_word_boundary():
+    label = _short_topic(TOPIC_A, limit=30)
+    assert len(label) <= 30
+    assert label.endswith("…")
+    assert " " not in label[-2:-1]  # no trailing partial word before the ellipsis
+    # No-space prefix falls back to a hard cut but still respects the limit.
+    hard = _short_topic("Supercalifragilisticexpialidocious", limit=10)
+    assert len(hard) <= 10 and hard.endswith("…")
+    # Short topics pass through untouched.
+    assert _short_topic("Climate", limit=30) == "Climate"
+
+
+def test_ambiguous_prefixes_fall_back_to_full_labels():
+    t1 = "Applications of machine learning in healthcare systems"
+    t2 = "Applications of machine learning in education systems"
+    labels = _topic_labels([t1, t2], limit=30)
+    # Both would shorten identically, so both keep their full text to stay distinct.
+    assert labels[t1] == t1 and labels[t2] == t2
+    assert labels[t1] != labels[t2]
+
+
+def test_empty_digest_renders_placeholder():
+    md = render_markdown(_digest([], [TOPIC_A]))
+    assert "No papers passed the relevance threshold today." in md
+    assert "Also matches" not in md
+
+
+if __name__ == "__main__":
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    for test in tests:
+        test()
+        print(f"ok  {test.__name__}")
+    print(f"\n{len(tests)} passed")


### PR DESCRIPTION
Papers matching multiple topics appear once under each topic section but gave no signal they were cross-listed. Add an italic note under each occurrence listing how many other topics the paper matches and their shortened labels. Markdown-render-only; no JSON/output-contract change, covers both run_digest and --rethreshold via the shared render_markdown.