### PR TITLE
perf(pipeline): reuse TL;DR cache + cache-friendly scoring prompt

### DIFF
--- a/src/digest.py
+++ b/src/digest.py
@@ -79,12 +79,21 @@ def select_papers(scored_df, threshold):
     return scored_df[scored_df["relevance"] >= threshold]
 
 
-def add_tldrs(llm_reader, paper_df, selected_df, config):
-    """Generate one TL;DR per selected paper (papers can match several topics)."""
+def add_tldrs(llm_reader, paper_df, selected_df, config, cached=None):
+    """Generate one TL;DR per selected paper, reusing any cached TL;DRs.
+
+    A TL;DR depends only on a paper's title and abstract — not on the topics or
+    the relevance threshold — so any paper already present in ``cached`` is
+    reused instead of re-queried (papers can match several topics).
+    """
+    cached = cached or {}
     selected_ids = selected_df["id"].unique()
-    papers = paper_df[paper_df["id"].isin(selected_ids)].to_dict(orient="records")
+    result = {pid: cached[pid] for pid in selected_ids if cached.get(pid)}
+    papers = paper_df[
+        paper_df["id"].isin(selected_ids) & ~paper_df["id"].isin(list(result))
+    ].to_dict(orient="records")
     if not papers:
-        return {}
+        return result
     logger.log_activity("tldr_generation", "started")
     tldrs = _run_concurrently(
         llm_reader.write_tldr,
@@ -93,7 +102,8 @@ def add_tldrs(llm_reader, paper_df, selected_df, config):
         "Writing TL;DRs",
     )
     logger.log_activity("tldr_generation", "completed", {"tldr_count": len(tldrs)})
-    return {item["id"]: item["tldr"] for item in tldrs}
+    result.update({item["id"]: item["tldr"] for item in tldrs})
+    return result
 
 
 def build_digest(date_str, paper_df, selected_df, tldrs, config):
@@ -420,11 +430,13 @@ def run_digest(config, date_str, output_dir):
     )
     scored_df = score_papers(llm_reader, paper_df, config)
     selected_df = select_papers(scored_df, config["relevance_threshold"])
-    tldrs = add_tldrs(llm_reader, paper_df, selected_df, config)
+    # Reuse TL;DRs already computed for this date (e.g. on a --force re-run) so
+    # only papers without a cached summary are re-queried.
+    cache = _load_tldr_cache(output_dir, date_str)
+    tldrs = add_tldrs(llm_reader, paper_df, selected_df, config, cached=cache)
     digest = build_digest(date_str, paper_df, selected_df, tldrs, config)
     scores = build_scores(date_str, scored_df, config)
     json_path, md_path = write_outputs(digest, scores, output_dir, date_str)
-    cache = _load_tldr_cache(output_dir, date_str)
     cache.update({k: v for k, v in tldrs.items() if v})
     _save_tldr_cache(output_dir, date_str, cache)
     logger.log_activity(

--- a/src/digest.py
+++ b/src/digest.py
@@ -309,11 +309,27 @@ def write_outputs(digest, scores, output_dir, date_str):
 
 
 def _load_tldr_cache(output_dir, date_str):
+    """Load the {paper_id: tldr} cache, tolerating a malformed file.
+
+    A corrupt or wrong-shaped cache must never abort a run (especially --force,
+    which should be able to repair its own outputs), so anything that is not a
+    dict of str->str is treated as empty and only valid string entries survive.
+    """
     cache_path = output_paths(output_dir, date_str)["tldrs"]
-    if cache_path.exists():
+    if not cache_path.exists():
+        return {}
+    try:
         with open(cache_path) as f:
-            return json.load(f)
-    return {}
+            data = json.load(f)
+    except (json.JSONDecodeError, OSError) as e:
+        print(f"Warning: ignoring unreadable TL;DR cache {cache_path}: {e}")
+        return {}
+    if not isinstance(data, dict):
+        print(f"Warning: ignoring malformed TL;DR cache {cache_path} (not an object)")
+        return {}
+    return {
+        k: v for k, v in data.items() if isinstance(k, str) and isinstance(v, str)
+    }
 
 
 def _save_tldr_cache(output_dir, date_str, tldrs):

--- a/src/llm.py
+++ b/src/llm.py
@@ -65,13 +65,11 @@ class LLMPaperReader:
         You are an assistant to help the user decide if a paper is very relevant to the topics of interests.
         """
 
+    # The static rubric + topics come first so the shared prefix is identical
+    # across every paper and providers can cache it; only the per-paper title
+    # and abstract vary, and they go last.
     user_message = """
-        Please read the following paper title and abstract:
-        --------------
-        Title: {title}
-        Abstract: {abstract}
-        --------------
-        Based on the title and abstract, please rate the direct relevance of the paper with the following topics:
+        Rate the direct relevance of a paper to each of the following topics:
         --------------
         {topics}
         --------------
@@ -83,6 +81,11 @@ class LLMPaperReader:
         If a topic description contains an exclusion (e.g. "NOT ..."), papers matching the exclusion must score 0.3 or lower on that topic.
         If the paper is relevant to the topic, provide a short explanation; otherwise, leave the explanation empty.
         Use your best guess when you are not sure.
+        Now read the paper's title and abstract and rate it:
+        --------------
+        Title: {title}
+        Abstract: {abstract}
+        --------------
     """
 
     tldr_system_message = """
@@ -103,10 +106,20 @@ class LLMPaperReader:
         self.client = create_client(provider, timeout_seconds)
         self.model = model
         self.topics = topics
+        # Render the topics into a clean bulleted block once, rather than
+        # stringifying the list (as a Python repr) on every scoring call. This
+        # block is part of the static, cacheable prompt prefix.
+        self.topics_block = self._format_topics(topics)
         # Some models (e.g. the GPT-5 family) only accept the default
         # temperature; drop the parameter permanently on the first rejection.
         self.use_temperature = True
         self.failure_count = 0
+
+    @staticmethod
+    def _format_topics(topics):
+        if isinstance(topics, str):
+            topics = [topics]
+        return "\n".join(f"- {topic}" for topic in topics)
 
     def _parse_completion(self, system_message, user_message, response_model):
         kwargs = {"temperature": 0.0} if self.use_temperature else {}
@@ -146,7 +159,7 @@ class LLMPaperReader:
                     self.user_message.format(
                         title=paper["title"],
                         abstract=paper["abstract"],
-                        topics=self.topics,
+                        topics=self.topics_block,
                     ),
                     Judgements,
                 )

--- a/test_digest.py
+++ b/test_digest.py
@@ -5,9 +5,20 @@ Covers the cross-topic note behavior shared by run_digest and --rethreshold,
 plus the short-label helpers.
 """
 
+import json
+import tempfile
+from pathlib import Path
+
 import pandas as pd
 
-from src.digest import add_tldrs, _short_topic, _topic_labels, render_markdown
+from src.digest import (
+    add_tldrs,
+    _load_tldr_cache,
+    _short_topic,
+    _topic_labels,
+    output_paths,
+    render_markdown,
+)
 from src.llm import LLMPaperReader
 
 TOPIC_A = "Security and safety of AI and language models"
@@ -146,6 +157,39 @@ def test_format_topics_is_a_clean_bulleted_block():
     assert "[" not in block and "'" not in block  # not a Python list repr
     # A bare string is treated as a single topic.
     assert LLMPaperReader._format_topics("solo") == "- solo"
+
+
+def test_scoring_prompt_puts_static_prefix_before_paper():
+    # Guards the caching optimization: the static rubric + topics must precede
+    # the per-paper title/abstract, or the shared prefix stops being cacheable.
+    prompt = LLMPaperReader.user_message.format(
+        topics=LLMPaperReader._format_topics([TOPIC_A, TOPIC_B]),
+        title="THE_TITLE",
+        abstract="THE_ABSTRACT",
+    )
+    topics_at = prompt.index(TOPIC_A)
+    rubric_at = prompt.index("Be strict and discriminating")
+    title_at = prompt.index("THE_TITLE")
+    abstract_at = prompt.index("THE_ABSTRACT")
+    assert topics_at < title_at and rubric_at < title_at
+    assert title_at < abstract_at
+
+
+def test_load_tldr_cache_tolerates_malformed_files():
+    with tempfile.TemporaryDirectory() as d:
+        out = Path(d)
+        cache_path = output_paths(out, "2026-07-22")["tldrs"]
+        # Missing file -> empty.
+        assert _load_tldr_cache(out, "2026-07-22") == {}
+        # Invalid JSON -> empty, no crash.
+        cache_path.write_text("{not json")
+        assert _load_tldr_cache(out, "2026-07-22") == {}
+        # Wrong top-level type -> empty.
+        cache_path.write_text(json.dumps(["a", "b"]))
+        assert _load_tldr_cache(out, "2026-07-22") == {}
+        # Non-string values are dropped; valid string entries survive.
+        cache_path.write_text(json.dumps({"p1": "ok", "p2": 5, "p3": None}))
+        assert _load_tldr_cache(out, "2026-07-22") == {"p1": "ok"}
 
 
 if __name__ == "__main__":

--- a/test_digest.py
+++ b/test_digest.py
@@ -5,7 +5,10 @@ Covers the cross-topic note behavior shared by run_digest and --rethreshold,
 plus the short-label helpers.
 """
 
-from src.digest import _short_topic, _topic_labels, render_markdown
+import pandas as pd
+
+from src.digest import add_tldrs, _short_topic, _topic_labels, render_markdown
+from src.llm import LLMPaperReader
 
 TOPIC_A = "Security and safety of AI and language models"
 TOPIC_B = "Factuality of AI systems, misinformation, and fact-checking"
@@ -87,6 +90,62 @@ def test_empty_digest_renders_placeholder():
     md = render_markdown(_digest([], [TOPIC_A]))
     assert "No papers passed the relevance threshold today." in md
     assert "Also matches" not in md
+
+
+class _ExplodingReader:
+    """A TL;DR reader that fails the test if it is ever called."""
+
+    def write_tldr(self, paper, max_retries=3):
+        raise AssertionError("write_tldr should not run for a fully cached paper")
+
+
+def test_add_tldrs_reuses_cache_without_querying():
+    paper_df = pd.DataFrame(
+        [{"id": "p1", "title": "t", "abstract": "a", "url": "u", "authors": ["x"]}]
+    )
+    selected_df = pd.DataFrame([{"id": "p1", "topic": TOPIC_A, "relevance": 0.9}])
+    config = {"number_of_concurrent_tasks": 2}
+    # Every selected paper is cached, so no LLM call should happen.
+    result = add_tldrs(
+        _ExplodingReader(), paper_df, selected_df, config, cached={"p1": "cached tldr"}
+    )
+    assert result == {"p1": "cached tldr"}
+
+
+class _StubReader:
+    """A TL;DR reader that returns a deterministic generated summary."""
+
+    def write_tldr(self, paper, max_retries=3):
+        return {"id": paper["id"], "tldr": f"generated:{paper['id']}"}
+
+
+def test_add_tldrs_only_generates_missing_papers():
+    paper_df = pd.DataFrame(
+        [
+            {"id": "p1", "title": "t1", "abstract": "a1", "url": "u1", "authors": ["x"]},
+            {"id": "p2", "title": "t2", "abstract": "a2", "url": "u2", "authors": ["y"]},
+        ]
+    )
+    selected_df = pd.DataFrame(
+        [
+            {"id": "p1", "topic": TOPIC_A, "relevance": 0.9},
+            {"id": "p2", "topic": TOPIC_A, "relevance": 0.85},
+        ]
+    )
+    config = {"number_of_concurrent_tasks": 2}
+    # p1 is cached (reused); p2's cache entry is empty, so it must be regenerated.
+    result = add_tldrs(
+        _StubReader(), paper_df, selected_df, config, cached={"p1": "cached", "p2": ""}
+    )
+    assert result == {"p1": "cached", "p2": "generated:p2"}
+
+
+def test_format_topics_is_a_clean_bulleted_block():
+    block = LLMPaperReader._format_topics([TOPIC_A, TOPIC_B])
+    assert block == f"- {TOPIC_A}\n- {TOPIC_B}"
+    assert "[" not in block and "'" not in block  # not a Python list repr
+    # A bare string is treated as a single topic.
+    assert LLMPaperReader._format_topics("solo") == "- solo"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Reduces repeated queries and repeated work in the scoring/TL;DR pipeline. Three changes:

- **Reuse the TL;DR cache in `run_digest`** — `add_tldrs` now accepts the cached `tldrs-<date>.json` and only queries papers without a summary. A TL;DR depends only on (title, abstract), not topics or threshold, so a `--force` re-run no longer re-buys TL;DRs it already has (mirrors the existing `--rethreshold` path).
- **Cache-friendly scoring prompt** — the scoring template put the variable title/abstract *first* and the static ~600-token rubric + topics *after*, which defeats prompt caching. Reordered so the static block leads and title/abstract go last, turning the shared prefix into a cacheable one (OpenAI auto-caches; other providers benefit on later concurrency waves) instead of reprocessing it for every paper.
- **Precompute the topics block** — formatted once as a clean bulleted list in `LLMPaperReader.__init__` instead of stringifying the list (Python repr) on every scoring call.

Already-good behavior confirmed during review: scoring is one call per paper covering all topics (not per topic), and cross-posted papers are deduped by id before scoring.

## Verification

- Offline tests extended 6 → 9 (TL;DR cache reuse, skip-empty-cache entries, topic formatting); all pass via `make test`.
- A/B re-scored the identical saved 2026-07-22 set (179 papers, same inputs) with the new prompt: mean |relevance drift| 0.047, only 1.6% threshold flips (80 → 76 selected). That is within `gpt-5-mini`'s inherent run-to-run sampling noise (it rejects `temperature`, so any re-run drifts), and the rubric/topic content is unchanged — only ordering and bullet formatting.

## Notes

- Pipeline-only change (`src/`); no skill/plugin surface touched, so no version bump per AGENTS.md.
- Possible follow-up: a one-shot warm-up scoring call before the concurrent fan-out would guarantee a warm cache on the first wave too.