### PR TITLE
feat(digest): show cross-topic note right after the title

### DIFF
--- a/src/digest.py
+++ b/src/digest.py
@@ -259,13 +259,8 @@ def render_markdown(digest):
         for match, paper in matches:
             lines.append(f"### [{paper['title']}]({paper['url']})")
             lines.append("")
-            lines.append(", ".join(paper["authors"]))
-            lines.append("")
-            if paper["tldr"]:
-                lines.append(f"**TL;DR:** {paper['tldr']}")
-                lines.append("")
-            lines.append(f"**Relevance {match['relevance']:.2f}** — {match['reason']}")
-            lines.append("")
+            # Cross-topic note first, right after the title, so a cross-listed
+            # paper is visible before the authors/TL;DR/relevance details.
             others = [
                 t["topic"]
                 for t in paper["matched_topics"]
@@ -276,6 +271,13 @@ def render_markdown(digest):
                 labels = ", ".join(topic_labels.get(t, _short_topic(t)) for t in others)
                 lines.append(f"*Also matches {len(others)} other {noun}: {labels}*")
                 lines.append("")
+            lines.append(", ".join(paper["authors"]))
+            lines.append("")
+            if paper["tldr"]:
+                lines.append(f"**TL;DR:** {paper['tldr']}")
+                lines.append("")
+            lines.append(f"**Relevance {match['relevance']:.2f}** — {match['reason']}")
+            lines.append("")
     return "\n".join(lines)
 
 

--- a/test_digest.py
+++ b/test_digest.py
@@ -68,6 +68,8 @@ def test_two_topics_uses_singular_noun():
     a_idx, b_idx = md.index(f"## {TOPIC_A}"), md.index(f"## {TOPIC_B}")
     a_note = md[a_idx:b_idx]
     assert _short_topic(TOPIC_B) in a_note and _short_topic(TOPIC_A) not in a_note
+    # The note sits right after the title, before the authors line.
+    assert a_note.index("Also matches") < a_note.index("Ada Lovelace")
 
 
 def test_three_topics_uses_plural_noun():


### PR DESCRIPTION
## Summary

Moves the `*Also matches N other topics*` line from the end of each paper block to **immediately after the title**, so a cross-listed paper is visible before the authors / TL;DR / relevance details.

Rendered result:

```
### [Paper title](url)

*Also matches 1 other topic: AI and health information…*

Author One, Author Two

**TL;DR:** …

**Relevance 1.00** — …
```

## Changes

- `src/digest.py` — reorder the per-paper block in `render_markdown` so the cross-topic note is emitted right after the title.
- `test_digest.py` — add a placement assertion (the note appears before the authors line) so the ordering can't silently regress.

## Verification

- Offline tests pass (`make test`, 6/6).
- Confirmed with a real `--rethreshold` render on 2026-07-22 that the note now precedes the authors.

Independent of the optimization work in #10; branched off `main`.